### PR TITLE
make errors available in result

### DIFF
--- a/lib/restforce/bulk/result.rb
+++ b/lib/restforce/bulk/result.rb
@@ -3,7 +3,7 @@ module Restforce
     class Result
       include Restforce::Bulk::Attributes
 
-      attr_accessor :id, :success, :created, :error, :job_id, :batch_id
+      attr_accessor :id, :success, :created, :errors, :job_id, :batch_id
 
       def initialize(attributes={})
         assign_attributes(attributes)


### PR DESCRIPTION
SalesForce API is returning results with `errors` key instead of `error`.
Thanks to that change there will be access to errors on each result from batch action.